### PR TITLE
Backport(#467106): DVR: Do not check HA state on DVR-only routers

### DIFF
--- a/neutron/Dockerfile
+++ b/neutron/Dockerfile
@@ -11,4 +11,9 @@ RUN sed -i -e 's/archive.ubuntu.com/jp.archive.ubuntu.com/g' \
     apt-get install -y devscripts software-properties-common
 
 RUN apt-get source neutron && apt-get build-dep -y neutron
-RUN cd neutron-8.4.0 && debuild -uc -us -b
+
+ADD patch patch
+WORKDIR neutron-8.4.0
+RUN ls -1 ../patch/*.patch | xargs cat | patch -Np1
+
+RUN debuild -uc -us -b

--- a/neutron/patch/09c2e15e.diff
+++ b/neutron/patch/09c2e15e.diff
@@ -1,0 +1,78 @@
+From 09c2e15eb5e0caf843d205bdf7cdcd93792f77d7 Mon Sep 17 00:00:00 2001
+From: Brian Haley <bhaley@redhat.com>
+Date: Wed, 17 May 2017 16:51:18 -0400
+Subject: [PATCH] DVR: Do not check HA state on DVR-only routers
+
+Trying to check HA state on a DVR-only compute node
+can trigger:
+
+AttributeError: 'DvrLocalRouter' object has no attribute 'ha_state'
+
+Also moved the mode assignment outside of the loops
+since it only needs to be done once.
+
+Co-Authored-By: Sean Redmond <sean.redmond1@gmail.com>
+Closes-bug: #1691427
+Change-Id: I3e48e06e76325939fbc9533b0198924bc96d600e
+(cherry picked from commit b748f2e9b9892443cd4ae072f69a26f8af6da2d1)
+---
+
+diff --git a/neutron/agent/l3/agent.py b/neutron/agent/l3/agent.py
+index 33d7148..d78e2aa 100644
+--- a/neutron/agent/l3/agent.py
++++ b/neutron/agent/l3/agent.py
+@@ -559,6 +559,10 @@
+         timestamp = timeutils.utcnow()
+         router_ids = []
+         chunk = []
++        is_snat_agent = (self.conf.agent_mode ==
++                         lib_const.L3_AGENT_MODE_DVR_SNAT)
++        is_dvr_only_agent = (self.conf.agent_mode ==
++                             lib_const.L3_AGENT_MODE_DVR)
+         try:
+             router_ids = self.plugin_rpc.get_router_ids(context)
+             # fetch routers by chunks to reduce the load on server and to
+@@ -574,14 +578,12 @@
+                         # need to keep fip namespaces as well
+                         ext_net_id = (r['external_gateway_info'] or {}).get(
+                             'network_id')
+-                        is_snat_agent = (self.conf.agent_mode ==
+-                            lib_const.L3_AGENT_MODE_DVR_SNAT)
+                         if ext_net_id:
+                             ns_manager.keep_ext_net(ext_net_id)
+                         elif is_snat_agent and not r.get('ha'):
+                             ns_manager.ensure_snat_cleanup(r['id'])
+                     # For HA routers check that DB state matches actual state
+-                    if r.get('ha'):
++                    if r.get('ha') and not is_dvr_only_agent:
+                         self.check_ha_state_for_router(
+                             r['id'], r.get(l3_constants.HA_ROUTER_STATE_KEY))
+                     update = queue.RouterUpdate(
+diff --git a/neutron/tests/unit/agent/l3/test_agent.py b/neutron/tests/unit/agent/l3/test_agent.py
+index e041294..5f9a830 100644
+--- a/neutron/tests/unit/agent/l3/test_agent.py
++++ b/neutron/tests/unit/agent/l3/test_agent.py
+@@ -253,6 +253,23 @@
+             check.assert_called_once_with(ha_id,
+                                           n_const.HA_ROUTER_STATE_STANDBY)
+ 
++    def test_periodic_sync_routers_task_not_check_ha_state_for_router(self):
++        # DVR-only agent should not trigger ha state check
++        self.conf.set_override('agent_mode', lib_constants.L3_AGENT_MODE_DVR)
++        agent = l3_agent.L3NATAgentWithStateReport(HOSTNAME, self.conf)
++        ha_id = _uuid()
++        active_routers = [
++            {'id': ha_id,
++             n_const.HA_ROUTER_STATE_KEY: n_const.HA_ROUTER_STATE_STANDBY,
++             'ha': True},
++            {'id': _uuid()}]
++        self.plugin_api.get_router_ids.return_value = [r['id'] for r
++                                                       in active_routers]
++        self.plugin_api.get_routers.return_value = active_routers
++        with mock.patch.object(agent, 'check_ha_state_for_router') as check:
++            agent.periodic_sync_routers_task(agent.context)
++            self.assertFalse(check.called)
++
+     def test_periodic_sync_routers_task_raise_exception(self):
+         agent = l3_agent.L3NATAgent(HOSTNAME, self.conf)
+         self.plugin_api.get_router_ids.return_value = ['fake_id']

--- a/neutron/patch/467106.patch
+++ b/neutron/patch/467106.patch
@@ -1,14 +1,14 @@
 diff -Naur a/neutron/agent/l3/agent.py b/neutron/agent/l3/agent.py
 --- a/neutron/agent/l3/agent.py	2017-08-03 12:14:53.000000000 +0000
-+++ b/neutron/agent/l3/agent.py	2017-08-07 05:42:49.022668763 +0000
++++ b/neutron/agent/l3/agent.py	2017-08-07 07:11:04.408950304 +0000
 @@ -563,6 +563,10 @@
          prev_router_ids = set(self.router_info)
          curr_router_ids = set()
          timestamp = timeutils.utcnow()
 +        is_snat_agent = (self.conf.agent_mode ==
-+                         lib_const.L3_AGENT_MODE_DVR_SNAT)
++                         l3_constants.L3_AGENT_MODE_DVR_SNAT)
 +        is_dvr_only_agent = (self.conf.agent_mode ==
-+                             lib_const.L3_AGENT_MODE_DVR)
++                             l3_constants.L3_AGENT_MODE_DVR)
  
          try:
              router_ids = ([self.conf.router_id] if self.conf.router_id else
@@ -30,19 +30,19 @@ diff -Naur a/neutron/agent/l3/agent.py b/neutron/agent/l3/agent.py
                      update = queue.RouterUpdate(
 diff -Naur a/neutron/tests/unit/agent/l3/test_agent.py b/neutron/tests/unit/agent/l3/test_agent.py
 --- a/neutron/tests/unit/agent/l3/test_agent.py	2017-08-03 12:14:53.000000000 +0000
-+++ b/neutron/tests/unit/agent/l3/test_agent.py	2017-08-07 05:41:37.894597214 +0000
++++ b/neutron/tests/unit/agent/l3/test_agent.py	2017-08-07 07:11:26.600977942 +0000
 @@ -247,6 +247,23 @@
              check.assert_called_once_with(ha_id,
                                            l3_constants.HA_ROUTER_STATE_STANDBY)
  
 +    def test_periodic_sync_routers_task_not_check_ha_state_for_router(self):
 +        # DVR-only agent should not trigger ha state check
-+        self.conf.set_override('agent_mode', lib_constants.L3_AGENT_MODE_DVR)
++        self.conf.set_override('agent_mode', l3_constants.L3_AGENT_MODE_DVR)
 +        agent = l3_agent.L3NATAgentWithStateReport(HOSTNAME, self.conf)
 +        ha_id = _uuid()
 +        active_routers = [
 +            {'id': ha_id,
-+             n_const.HA_ROUTER_STATE_KEY: n_const.HA_ROUTER_STATE_STANDBY,
++             l3_constants.HA_ROUTER_STATE_KEY: l3_constants.HA_ROUTER_STATE_STANDBY,
 +             'ha': True},
 +            {'id': _uuid()}]
 +        self.plugin_api.get_router_ids.return_value = [r['id'] for r

--- a/neutron/patch/467106.patch
+++ b/neutron/patch/467106.patch
@@ -1,46 +1,26 @@
-From 09c2e15eb5e0caf843d205bdf7cdcd93792f77d7 Mon Sep 17 00:00:00 2001
-From: Brian Haley <bhaley@redhat.com>
-Date: Wed, 17 May 2017 16:51:18 -0400
-Subject: [PATCH] DVR: Do not check HA state on DVR-only routers
-
-Trying to check HA state on a DVR-only compute node
-can trigger:
-
-AttributeError: 'DvrLocalRouter' object has no attribute 'ha_state'
-
-Also moved the mode assignment outside of the loops
-since it only needs to be done once.
-
-Co-Authored-By: Sean Redmond <sean.redmond1@gmail.com>
-Closes-bug: #1691427
-Change-Id: I3e48e06e76325939fbc9533b0198924bc96d600e
-(cherry picked from commit b748f2e9b9892443cd4ae072f69a26f8af6da2d1)
----
-
-diff --git a/neutron/agent/l3/agent.py b/neutron/agent/l3/agent.py
-index 33d7148..d78e2aa 100644
---- a/neutron/agent/l3/agent.py
-+++ b/neutron/agent/l3/agent.py
-@@ -559,6 +559,10 @@
+diff -Naur a/neutron/agent/l3/agent.py b/neutron/agent/l3/agent.py
+--- a/neutron/agent/l3/agent.py	2017-08-03 12:14:53.000000000 +0000
++++ b/neutron/agent/l3/agent.py	2017-08-07 05:42:49.022668763 +0000
+@@ -563,6 +563,10 @@
+         prev_router_ids = set(self.router_info)
+         curr_router_ids = set()
          timestamp = timeutils.utcnow()
-         router_ids = []
-         chunk = []
 +        is_snat_agent = (self.conf.agent_mode ==
 +                         lib_const.L3_AGENT_MODE_DVR_SNAT)
 +        is_dvr_only_agent = (self.conf.agent_mode ==
 +                             lib_const.L3_AGENT_MODE_DVR)
+ 
          try:
-             router_ids = self.plugin_rpc.get_router_ids(context)
-             # fetch routers by chunks to reduce the load on server and to
-@@ -574,14 +578,12 @@
+             router_ids = ([self.conf.router_id] if self.conf.router_id else
+@@ -580,14 +584,12 @@
                          # need to keep fip namespaces as well
                          ext_net_id = (r['external_gateway_info'] or {}).get(
                              'network_id')
 -                        is_snat_agent = (self.conf.agent_mode ==
--                            lib_const.L3_AGENT_MODE_DVR_SNAT)
+-                            l3_constants.L3_AGENT_MODE_DVR_SNAT)
                          if ext_net_id:
                              ns_manager.keep_ext_net(ext_net_id)
-                         elif is_snat_agent and not r.get('ha'):
+                         elif is_snat_agent:
                              ns_manager.ensure_snat_cleanup(r['id'])
                      # For HA routers check that DB state matches actual state
 -                    if r.get('ha'):
@@ -48,13 +28,12 @@ index 33d7148..d78e2aa 100644
                          self.check_ha_state_for_router(
                              r['id'], r.get(l3_constants.HA_ROUTER_STATE_KEY))
                      update = queue.RouterUpdate(
-diff --git a/neutron/tests/unit/agent/l3/test_agent.py b/neutron/tests/unit/agent/l3/test_agent.py
-index e041294..5f9a830 100644
---- a/neutron/tests/unit/agent/l3/test_agent.py
-+++ b/neutron/tests/unit/agent/l3/test_agent.py
-@@ -253,6 +253,23 @@
+diff -Naur a/neutron/tests/unit/agent/l3/test_agent.py b/neutron/tests/unit/agent/l3/test_agent.py
+--- a/neutron/tests/unit/agent/l3/test_agent.py	2017-08-03 12:14:53.000000000 +0000
++++ b/neutron/tests/unit/agent/l3/test_agent.py	2017-08-07 05:41:37.894597214 +0000
+@@ -247,6 +247,23 @@
              check.assert_called_once_with(ha_id,
-                                           n_const.HA_ROUTER_STATE_STANDBY)
+                                           l3_constants.HA_ROUTER_STATE_STANDBY)
  
 +    def test_periodic_sync_routers_task_not_check_ha_state_for_router(self):
 +        # DVR-only agent should not trigger ha state check


### PR DESCRIPTION
https://review.openstack.org/#/c/467106/

をバックポートします。